### PR TITLE
Revert "Bump Newtonsoft.Json from 12.0.1 to 13.0.1"

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Reverts 8Mi-Tech/8Mi-MCAriaPlus_net#3
根据GitHub的通知，我们决定先回退插件